### PR TITLE
Add option "endOfLine" to Prettier

### DIFF
--- a/template/.prettierrc
+++ b/template/.prettierrc
@@ -3,5 +3,6 @@
   "singleQuote": true,
   "tabWidth": 4,
   "trailingComma": "none",
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
New option "endOfLine = auto" overwrites default "endOfLine = lf".